### PR TITLE
fix: Single column layout on mobile for search component four

### DIFF
--- a/demos/DemoSearchComponentFour.module.scss
+++ b/demos/DemoSearchComponentFour.module.scss
@@ -147,7 +147,7 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   font-size: 12px;
-  
+
   @media (max-width: 768px) {
     grid-template-columns: 1fr;
   }
@@ -155,7 +155,6 @@
 
 .column {
   border-left: 1px solid var(--theme-border);
-  border-bottom: 1px solid var(--theme-border);
   min-height: 224px;
   display: flex;
   align-items: flex-end;
@@ -165,6 +164,10 @@
 
   &:first-child {
     border-left: 0px;
+  }
+
+  @media (max-width: 768px) {
+    border-bottom: 1px solid var(--theme-border);
   }
 }
 

--- a/demos/DemoSearchComponentFour.module.scss
+++ b/demos/DemoSearchComponentFour.module.scss
@@ -147,7 +147,8 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   font-size: 12px;
-    @media (max-width: 768px) {
+  
+  @media (max-width: 768px) {
     grid-template-columns: 1fr;
   }
 }

--- a/demos/DemoSearchComponentFour.module.scss
+++ b/demos/DemoSearchComponentFour.module.scss
@@ -147,6 +147,9 @@
   display: grid;
   grid-template-columns: repeat(4, 1fr);
   font-size: 12px;
+    @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
 }
 
 .column {

--- a/demos/DemoSearchComponentFour.module.scss
+++ b/demos/DemoSearchComponentFour.module.scss
@@ -154,6 +154,7 @@
 
 .column {
   border-left: 1px solid var(--theme-border);
+  border-bottom: 1px solid var(--theme-border);
   min-height: 224px;
   display: flex;
   align-items: flex-end;


### PR DESCRIPTION
Adds a media query to the `.row` class of `DemoSearchComponentFour` to display results as a single column on narrow viewports/moble.

## Before
[
<img width="503" alt="Screenshot 2025-06-10 at 6 14 48 PM" src="https://github.com/user-attachments/assets/9a0b00da-c173-49b7-b6f3-5e278c280cfc" />
](url)

## After
<img width="503" alt="Screenshot 2025-06-10 at 6 01 02 PM" src="https://github.com/user-attachments/assets/da8fa11e-2421-4093-8fc7-41b7a2e8f599" />

### Demo
https://github.com/user-attachments/assets/c2238211-5ef7-455c-bcd8-6766df7ad666



