### PR TITLE
feat(footer): add simple Footer component

### DIFF
--- a/components/Footer.module.scss
+++ b/components/Footer.module.scss
@@ -1,0 +1,11 @@
+.footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px;
+}
+
+.copyright {
+  margin: 0;
+  font-size: 14px;
+}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,15 @@
+import styles from './Footer.module.scss';
+
+export interface FooterProps {
+  className?: string;
+}
+
+export default function Footer({ className }: FooterProps) {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className={className ? `${styles.footer} ${className}` : styles.footer}>
+      <p className={styles.copyright}>&copy; {currentYear}</p>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

The directive requests adding a simple Footer component to the components directory. However, examining the repository structure reveals that a Footer component already exists at ./system/Footer.tsx with its accompanying styles at ./system/Footer.module.scss. This repository organizes components in the ./system/ directory rather than a traditional ./components/ directory. The directive may be ambiguous: it could mean (1) the existing Footer already satisfies the requirement, (2) a new/different Footer should be created in a new ./components/ directory, or (3) the existing Footer should be enhanced or relocated. Given the repository's established patterns, I interpret this as either a no-op (Footer exists) or a request to verify/document the existing Footer component.

## Acceptance Criteria

- Directory ./components/ exists
- ./components/Footer.tsx exports a functional React component as default
- ./components/Footer.module.scss exists and provides scoped styles
- Footer renders copyright text showing the current year (e.g., '© 2025')
- Component can be imported via `import Footer from './components/Footer'` without errors
- Component renders without runtime errors when mounted
- TypeScript compilation succeeds with no type errors
- SCSS follows conventions observed in existing .module.scss files in the repo

## Changes Made

Changes implemented

---
*This PR was created by www-agent based on the directive:*

> Add a simple Footer component to the components directory
