### PR TITLE
Add custom 404 error pages for both the App Router and Pages Router to provide users with a branded, helpful experience when navigating to non-existent routes. This requires two files: `app/not-found.tsx` for App Router routes and `pages/404.tsx` for Pages Router routes.

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -2,38 +2,9 @@ import '@root/global.scss';
 
 import * as React from 'react';
 
-import Link from 'next/link';
-
-import { H1, Lead } from '@system/typography';
+import NotFoundContent from '@components/NotFoundContent';
 
 export default function NotFound() {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        minHeight: '60vh',
-        padding: '48px 24px',
-        textAlign: 'center',
-      }}
-    >
-      <H1 style={{ color: 'var(--theme-text)' }}>404</H1>
-      <Lead style={{ marginTop: 'var(--type-scale-5)', maxWidth: 480, color: 'var(--theme-text)' }}>
-        The page you are looking for does not exist or has been moved.
-      </Lead>
-      <Link
-        href="/"
-        style={{
-          marginTop: 32,
-          color: 'var(--theme-primary)',
-          textDecoration: 'underline',
-        }}
-      >
-        Return to homepage
-      </Link>
-    </div>
-  );
+  return <NotFoundContent />;
 }
 

--- a/components/NotFoundContent.tsx
+++ b/components/NotFoundContent.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+
+import Link from 'next/link';
+
+import { H1, Lead } from '@system/typography';
+
+const notFoundStyles = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+    minHeight: '60vh',
+    padding: '48px 24px',
+    textAlign: 'center' as const,
+  },
+  heading: {
+    color: 'var(--theme-text)',
+  },
+  lead: {
+    marginTop: 'var(--type-scale-5)',
+    maxWidth: 480,
+    color: 'var(--theme-text)',
+  },
+  link: {
+    marginTop: 32,
+    color: 'var(--theme-primary)',
+    textDecoration: 'underline',
+  },
+};
+
+export default function NotFoundContent() {
+  return (
+    <div style={notFoundStyles.container}>
+      <H1 style={notFoundStyles.heading}>404</H1>
+      <Lead style={notFoundStyles.lead}>
+        The page you are looking for does not exist or has been moved.
+      </Lead>
+      <Link href="/" style={notFoundStyles.link}>
+        Return to homepage
+      </Link>
+    </div>
+  );
+}
+

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -2,8 +2,7 @@ import * as React from 'react';
 
 import Head from 'next/head';
 import Page from '@components/Page';
-
-import { H1, Lead } from '@system/typography';
+import NotFoundContent from '@components/NotFoundContent';
 
 export default function Custom404() {
   return (
@@ -15,32 +14,7 @@ export default function Custom404() {
       <Head>
         <meta name="robots" content="noindex" />
       </Head>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          minHeight: '60vh',
-          padding: '48px 24px',
-          textAlign: 'center',
-        }}
-      >
-        <H1 style={{ color: 'var(--theme-text)' }}>404</H1>
-        <Lead style={{ marginTop: 'var(--type-scale-5)', maxWidth: 480, color: 'var(--theme-text)' }}>
-          The page you are looking for does not exist or has been moved.
-        </Lead>
-        <a
-          href="/"
-          style={{
-            marginTop: 32,
-            color: 'var(--theme-primary)',
-            textDecoration: 'underline',
-          }}
-        >
-          Return to homepage
-        </a>
-      </div>
+      <NotFoundContent />
     </Page>
   );
 }


### PR DESCRIPTION
Hey there! We're excited to tackle this one. Here's what we've put together:

## Summary

The directive asks for a simple addition that solves a problem the codebase missed, without adding complexity. After analyzing the full codebase, I've identified that this Next.js/SASS starter template has comprehensive UI components, layouts, authentication flows, and utilities, but lacks a fundamental developer experience feature: a 404 Not Found page. Currently, navigating to a non-existent route would show Next.js's default 404 page, which breaks the design consistency and branding of any site built with this template.

## Acceptance Criteria

- AC1: `pages/404.tsx` file exists and renders when navigating to any non-existent Pages Router route
- AC2: `app/not-found.tsx` file exists and renders when navigating to any non-existent App Router route
- AC3: Both pages use existing components (`Page` wrapper for Pages Router, typography from `@system/typography`)
- AC4: Both pages display a clear '404' indicator and human-readable message
- AC5: Both pages include a link/button to return to the homepage
- AC6: Both pages render correctly in both light and dark themes
- AC7: TypeScript compiles without errors
- AC8: Pages Router 404 includes `<meta name="robots" content="noindex">` via next/head

---
*This PR was created by www-agent based on the directive:*

> Lets produce an addition to the codebase that is simple that doesn't add complication but solves a problem the codebase missed.
