### PR TITLE
Create a custom 404 error page at pages/404.tsx that matches the site's design language and provides users with clear navigation back to the homepage when they hit non-existent routes.

### DIFF
--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+import Content from '@system/layouts/Content';
+import GlobalModalManager from '@system/modals/GlobalModalManager';
+import Navigation from '@system/Navigation';
+import Page from '@components/Page';
+import SectionFullHeight from '@system/sections/SectionFullHeight';
+
+import { H1, Lead } from '@system/typography';
+
+function NotFoundPage(props) {
+  return (
+    <Page
+      title="404 - Page Not Found"
+      description="The page you're looking for doesn't exist or has been moved."
+      url="https://wireframes.internet.dev/404"
+    >
+      <Navigation />
+      <SectionFullHeight>
+        <Content>
+          <H1>404</H1>
+          <Lead style={{ marginTop: `var(--type-scale-5)` }}>
+            This page doesn't exist or has been moved.
+          </Lead>
+          <Lead style={{ marginTop: `var(--type-scale-5)` }}>
+            <a href="/">Go back home</a>
+          </Lead>
+        </Content>
+      </SectionFullHeight>
+      <GlobalModalManager />
+    </Page>
+  );
+}
+
+export default NotFoundPage;
+


### PR DESCRIPTION
Hey there! We're excited to tackle this one. Here's what we've put together:

## Summary

The directive asks for a simple addition to the codebase that solves a problem the codebase missed, while strictly following existing conventions. After analyzing the full codebase, I observe that this Next.js/SASS starter template has extensive UI components, demos, and examples, but lacks a fundamental utility that would benefit developers: a 404 (Not Found) page. Currently, if users navigate to a non-existent route, they would see Next.js's default 404 page rather than a styled, on-brand page. This is a simple, focused addition that doesn't add complexity but fills a genuine gap.

## Acceptance Criteria

- AC1: Visiting any non-existent route (e.g., /this-does-not-exist) renders the custom 404 page instead of Next.js default
- AC2: The 404 page uses the Page component wrapper with appropriate title, description, and url props
- AC3: The 404 page uses H1 typography component for the '404' heading
- AC4: The 404 page uses Lead typography component for the explanatory message
- AC5: The 404 page includes a visible, clickable link back to homepage (/)
- AC6: The 404 page uses Navigation component at the top
- AC7: The 404 page uses SectionFullHeight and Content layout components
- AC8: No new npm dependencies are added to package.json
- AC9: Page renders correctly in both light and dark themes (uses existing CSS variables)
- AC10: Page works without JavaScript (SSR renders properly)

---
*This PR was created by www-agent based on the directive:*

> Lets produce an addition to the codebase that is simple that doesn't add complication but solves a problem the codebase missed. You must follow the codebases conventions exactly, the codebase adheres to a specific style.
